### PR TITLE
Minor refactoring for DataProtection

### DIFF
--- a/src/Quidjibo.DataProtection/Constants/KeyContext.cs
+++ b/src/Quidjibo.DataProtection/Constants/KeyContext.cs
@@ -1,0 +1,15 @@
+﻿namespace Quidjibo.DataProtection.Constants
+{
+    public class KeyContext
+    {
+        /// <summary>
+        /// Key derived for cipher
+        /// </summary>
+        public static byte[] Cipher = new byte[] { 0x01 };
+
+        /// <summary>
+        /// Key derived for MAC
+        /// </summary>
+        public static byte[] Mac = new byte[] { 0x02 };
+    }
+}

--- a/src/Quidjibo.DataProtection/Exceptions/MacMismatchException.cs
+++ b/src/Quidjibo.DataProtection/Exceptions/MacMismatchException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Quidjibo.DataProtection.Exceptions
+{
+    public class MacMismatchException : Exception
+    {
+        public MacMismatchException()
+        {
+        }
+
+        public MacMismatchException(string message)
+            : base(message)
+        {
+        }
+
+        public MacMismatchException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Quidjibo.DataProtection/Protectors/HKDF.cs
+++ b/src/Quidjibo.DataProtection/Protectors/HKDF.cs
@@ -27,7 +27,7 @@ namespace Quidjibo.DataProtection.Protectors
         /// <returns>A pseudorandom key.</returns>
         public byte[] Extract(byte[] salt, byte[] inputKeyMaterial)
         {
-            _hmac.Key = salt ?? new byte[] { };
+            _hmac.Key = salt ?? new byte[0];
             return _hmac.ComputeHash(inputKeyMaterial);
         }
 
@@ -44,17 +44,22 @@ namespace Quidjibo.DataProtection.Protectors
                 throw new Exception("Invalid length. Must be less than or equal to 255 * Hash Length.");
             }
 
+            if (info == null)
+            {
+                info = new byte[0];
+            }
+
             _hmac.Key = pseudoRandomKey;
 
             var n = Convert.ToInt32(Math.Ceiling(length / (_hmac.HashSize / 8.0)));
 
-            var lastT = new byte[] { };
+            var lastT = new byte[0];
 
             var t = new List<byte>();
-            for(var i = 1; i <= n; i++)
+            var ikm = new List<byte>((_hmac.HashSize / 8) + info.Length + 1);
+            for (var i = 1; i <= n; i++)
             {
                 // T(N) = HMAC-Hash(PRK, T(N-1) | info | 0x0N)
-                var ikm = new List<byte>();
                 ikm.AddRange(lastT);
                 ikm.AddRange(info);
                 ikm.Add((byte)i);
@@ -63,6 +68,7 @@ namespace Quidjibo.DataProtection.Protectors
                 t.AddRange(tn);
 
                 lastT = tn;
+                ikm.Clear();
             }
 
             return t.Take(length).ToArray();


### PR DESCRIPTION
Minor housekeeping. Tidied up MAC verification. MacMismatchException occurs after all bytes are compared to avoid potential timing attacks.