### PR TITLE
Fixing web proxy through Sql Server bug. 

### DIFF
--- a/src/Quidjibo.SqlServer/Factories/SqlWorkProviderFactory.cs
+++ b/src/Quidjibo.SqlServer/Factories/SqlWorkProviderFactory.cs
@@ -49,7 +49,7 @@ namespace Quidjibo.SqlServer.Factories
                 return new SqlWorkProvider(
                     _loggerFactory.CreateLogger<SqlWorkProvider>(),
                     _sqlServerQuidjiboConfiguration.ConnectionString,
-                    _sqlServerQuidjiboConfiguration.Queues,
+                    queues,
                     _sqlServerQuidjiboConfiguration.LockInterval,
                     _sqlServerQuidjiboConfiguration.BatchSize);
             }


### PR DESCRIPTION
Work items are retrieved for the queues in the Sql Server configuration, rather than those requested by the web proxy.