### PR TITLE
Optimize HKDF implementation.

### DIFF
--- a/src/Quidjibo.DataProtection.Tests/Protectors/HKDFTests.cs
+++ b/src/Quidjibo.DataProtection.Tests/Protectors/HKDFTests.cs
@@ -37,14 +37,12 @@ namespace Quidjibo.DataProtection.Tests.Protectors
             DisplayName = "RFC 5869 A.3")]
         public void Rfc5869HmacSha256TestVector(string salt, string ikm, string info, int length, string expectedPrk, string expectedOkm)
         {
-            using (var hkdf = new Hkdf<HMACSHA256>())
-            {
-                var prk = hkdf.Extract(StringToByteArray(salt), StringToByteArray(ikm));
-                ByteArrayToString(prk).Should().BeEquivalentTo(expectedPrk);
+            var hkdf = new Hkdf(HashAlgorithmName.SHA256);
+            var prk = hkdf.Extract(StringToByteArray(salt), StringToByteArray(ikm));
+            ByteArrayToString(prk).Should().BeEquivalentTo(expectedPrk);
 
-                var okm = hkdf.Expand(prk, StringToByteArray(info), length);
-                ByteArrayToString(okm).Should().BeEquivalentTo(expectedOkm);
-            }
+            var okm = hkdf.Expand(prk, StringToByteArray(info), length);
+            ByteArrayToString(okm).Should().BeEquivalentTo(expectedOkm);
         }
 
         [DataTestMethod]
@@ -82,14 +80,12 @@ namespace Quidjibo.DataProtection.Tests.Protectors
             DisplayName = "RFC 5869 A.7")]
         public void Rfc5869HmacSha1TestVector(string salt, string ikm, string info, int length, string expectedPrk, string expectedOkm)
         {
-            using (var hkdf = new Hkdf<HMACSHA1>())
-            {
-                var prk = hkdf.Extract(StringToByteArray(salt), StringToByteArray(ikm));
-                ByteArrayToString(prk).Should().BeEquivalentTo(expectedPrk);
+            var hkdf = new Hkdf(HashAlgorithmName.SHA1);
+            var prk = hkdf.Extract(StringToByteArray(salt), StringToByteArray(ikm));
+            ByteArrayToString(prk).Should().BeEquivalentTo(expectedPrk);
 
-                var okm = hkdf.Expand(prk, StringToByteArray(info), length);
-                ByteArrayToString(okm).Should().BeEquivalentTo(expectedOkm);
-            }
+            var okm = hkdf.Expand(prk, StringToByteArray(info), length);
+            ByteArrayToString(okm).Should().BeEquivalentTo(expectedOkm);
         }
 
         public static string ByteArrayToString(byte[] ba)

--- a/src/Quidjibo.DataProtection/Protectors/AesPayloadProtector.cs
+++ b/src/Quidjibo.DataProtection/Protectors/AesPayloadProtector.cs
@@ -103,12 +103,10 @@ namespace Quidjibo.DataProtection.Protectors
         private async Task<(byte[] CipherKey, byte[] MacKey)> ExpandKeysAsync(CancellationToken cancellationToken)
         {
             var key = await _keyProvider.GetKeyAsync(cancellationToken);
-            using (var hkdf = new Hkdf<HMACSHA256>())
-            {
-                var cipherKey = hkdf.Expand(key, KeyContext.Cipher, 32);
-                var macKey = hkdf.Expand(key, KeyContext.Mac, 32);
-                return (cipherKey, macKey);
-            }
+            var hkdf = new Hkdf(HashAlgorithmName.SHA256);
+            var cipherKey = hkdf.Expand(key, KeyContext.Cipher, 32);
+            var macKey = hkdf.Expand(key, KeyContext.Mac, 32);
+            return (cipherKey, macKey);
         }
     }
 }

--- a/src/Quidjibo.DataProtection/Quidjibo.DataProtection.csproj
+++ b/src/Quidjibo.DataProtection/Quidjibo.DataProtection.csproj
@@ -13,10 +13,14 @@
     <Authors>Smiggleworth</Authors>
     <Company>Smiggleworth</Company>
     <Version>1.0.0</Version>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Quidjibo\Quidjibo.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a smallish optimizations of the HKDF implementation.

Highlight reel: expand is slightly faster but allocates about half the memory.

The goal of the PR was to decrease the amount of GC pressure by allocating less memory where possible. This PR is somewhat constrained by targeting `netstandard2.0` instead of `netcoreapp2.1`. `netstandard2.1`, when released, will allow significant more improvements since the required APIs that are in `netcoreapp2.1` will become part of the standard.

BenchmarkDotNet details (expandable).

<details>
<summary>Existing Implementation</summary>
<pre>
BenchmarkDotNet=v0.11.1, OS=macOS Mojave 10.14 (18A391) [Darwin 18.0.0]
Intel Core i7-6567U CPU 3.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.1.403
  [Host]     : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT


 Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
--------------- |---------:|----------:|----------:|-------:|----------:|
   Extract_sha1 | 1.499 us | 0.0145 us | 0.0121 us | 0.1163 |     248 B |
 Extract_sha256 | 1.913 us | 0.0137 us | 0.0121 us | 0.1259 |     264 B |
 Extract_sha512 | 2.371 us | 0.0244 us | 0.0216 us | 0.1526 |     328 B |


Method | ExpandSize |     Mean |     Error |    StdDev |   Median |  Gen 0 | Allocated |
-------------- |----------- |---------:|----------:|----------:|---------:|-------:|----------:|
   Expand_sha1 |         32 | 3.311 us | 0.0706 us | 0.1636 us | 3.230 us | 0.4120 |     872 B |
 Expand_sha256 |         32 | 2.354 us | 0.0139 us | 0.0123 us | 2.353 us | 0.3281 |     688 B |
 Expand_sha512 |         32 | 2.929 us | 0.0480 us | 0.0607 us | 2.907 us | 0.3891 |     816 B |
   Expand_sha1 |         64 | 5.590 us | 0.0446 us | 0.0395 us | 5.593 us | 0.6256 |    1328 B |
 Expand_sha256 |         64 | 4.101 us | 0.0383 us | 0.0340 us | 4.093 us | 0.4730 |    1000 B |
 Expand_sha512 |         64 | 2.856 us | 0.0110 us | 0.0092 us | 2.856 us | 0.4044 |     848 B |
   Expand_sha1 |        128 | 9.457 us | 0.0876 us | 0.0776 us | 9.437 us | 0.9766 |    2056 B |
 Expand_sha256 |        128 | 7.204 us | 0.0343 us | 0.0287 us | 7.194 us | 0.7629 |    1600 B |
 Expand_sha512 |        128 | 5.055 us | 0.0801 us | 0.0669 us | 5.037 us | 0.6409 |    1352 B |
</pre>
</details>

<details>
<summary>Proposed Implementation</summary>
<pre>
BenchmarkDotNet=v0.11.1, OS=macOS Mojave 10.14 (18A391) [Darwin 18.0.0]
Intel Core i7-6567U CPU 3.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.1.403
  [Host]     : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT


  Method | Algorithm |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
-------- |---------- |---------:|----------:|----------:|-------:|-------:|----------:|
 Extract |      SHA1 | 1.587 us | 0.0302 us | 0.0310 us | 0.1469 | 0.0477 |     312 B |
 Extract |    SHA256 | 1.868 us | 0.0353 us | 0.0347 us | 0.1507 | 0.0496 |     320 B |
 Extract |    SHA512 | 2.283 us | 0.0381 us | 0.0356 us | 0.1640 | 0.0534 |     352 B |





 Method | ExpandSize | Algorithm |     Mean |     Error |    StdDev |   Median |  Gen 0 | Allocated |
------- |----------- |---------- |---------:|----------:|----------:|---------:|-------:|----------:|
 Expand |         32 |      SHA1 | 2.630 us | 0.0171 us | 0.0152 us | 2.630 us | 0.2213 |     464 B |
 Expand |         32 |    SHA256 | 1.999 us | 0.0196 us | 0.0174 us | 1.996 us | 0.2022 |     424 B |
 Expand |         32 |    SHA512 | 2.419 us | 0.0123 us | 0.0109 us | 2.415 us | 0.2174 |     456 B |
 Expand |         64 |      SHA1 | 5.194 us | 0.1971 us | 0.5717 us | 4.883 us | 0.2747 |     592 B |
 Expand |         64 |    SHA256 | 3.385 us | 0.0615 us | 0.0545 us | 3.369 us | 0.2403 |     512 B |
 Expand |         64 |    SHA512 | 2.462 us | 0.0487 us | 0.0667 us | 2.443 us | 0.2289 |     488 B |
 Expand |        128 |      SHA1 | 7.992 us | 0.0764 us | 0.0678 us | 7.975 us | 0.3662 |     800 B |
 Expand |        128 |    SHA256 | 6.362 us | 0.1442 us | 0.1543 us | 6.311 us | 0.3204 |     688 B |
 Expand |        128 |    SHA512 | 4.314 us | 0.0363 us | 0.0303 us | 4.306 us | 0.3052 |     640 B |
</pre>
</details>