### PR TITLE
HMAC

### DIFF
--- a/src/Quidjibo.DataProtection.Tests/Protectors/AesPayloadProtectorTests.cs
+++ b/src/Quidjibo.DataProtection.Tests/Protectors/AesPayloadProtectorTests.cs
@@ -49,11 +49,16 @@ namespace Quidjibo.DataProtection.Tests.Protectors
 
             var protectedPayload = await _sut.ProtectAsync(payload, CancellationToken.None);
 
-            protectedPayload[49] = (byte)(protectedPayload[49] ^ 255);
+            for(var i = 1; i < protectedPayload.Length; i++)
+            {
+                var payloadCopy = new byte[protectedPayload.Length];
+                protectedPayload.AsSpan().CopyTo(payloadCopy);
+                payloadCopy[i] ^= 255;
 
-            Func<Task> sut = async () => await _sut.UnprotectAsync(protectedPayload, CancellationToken.None);
+                Func<Task> sut = async () => await _sut.UnprotectAsync(payloadCopy, CancellationToken.None);
 
-            sut.Should().Throw<Exception>().WithMessage("MAC mismatch");
+                sut.Should().Throw<Exception>().WithMessage("MAC mismatch");
+            }
         }
 
 

--- a/src/Quidjibo.DataProtection/Protectors/AesPayloadProtector.cs
+++ b/src/Quidjibo.DataProtection/Protectors/AesPayloadProtector.cs
@@ -12,6 +12,11 @@ namespace Quidjibo.DataProtection.Protectors
 {
     public class AesPayloadProtector : IPayloadProtector
     {
+        private const int VERSION_SIZE = 1;
+        private const int IV_SIZE = 16;
+        private const int MAC_SIZE = 32;
+        private static readonly byte[] _version1 = new byte[] { 1 };
+
         private readonly IKeyProvider _keyProvider;
 
         public AesPayloadProtector(IKeyProvider keyProvider)
@@ -22,11 +27,12 @@ namespace Quidjibo.DataProtection.Protectors
         /*
          * Encrypted payload:
          * 
-         * |--- IV (16 bytes) ---|--- MAC (32 bytes) ---|--- Ciphertext (n bytes) ---|
+         * |--- Version (1 byte) ---|--- IV (16 bytes) ---|--- MAC (32 bytes) ---|--- Ciphertext (n bytes) ---|
          * 
          */
         public async Task<byte[]> ProtectAsync(byte[] payload, CancellationToken cancellationToken)
         {
+            var version = new ArraySegment<byte>(_version1);
             var keys = await ExpandKeysAsync(cancellationToken);
             using (var aes = Aes.Create())
             using (var crypto = aes.CreateEncryptor(keys.CipherKey, aes.IV))
@@ -36,65 +42,84 @@ namespace Quidjibo.DataProtection.Protectors
                 await cryptoStream.WriteAsync(payload, 0, payload.Length, cancellationToken);
                 cryptoStream.FlushFinalBlock();
                 var encryptedPayload = stream.ToArray();
-                var mac = ComputeMac(keys.MacKey, encryptedPayload, 0, encryptedPayload.Length);
-                var outputBuffer = new byte[encryptedPayload.Length + aes.IV.Length + mac.Length];
-                Buffer.BlockCopy(aes.IV, 0, outputBuffer, 0, aes.IV.Length);
-                Buffer.BlockCopy(mac, 0, outputBuffer, aes.IV.Length, mac.Length);
-                Buffer.BlockCopy(encryptedPayload, 0, outputBuffer, aes.IV.Length + mac.Length, encryptedPayload.Length);
+                var ivSegment = new ArraySegment<byte>(aes.IV);
+                var payloadSegment = new ArraySegment<byte>(encryptedPayload);
+                var mac = ComputeMac(keys.MacKey, version, ivSegment, payloadSegment);
+                var outputBuffer = new byte[VERSION_SIZE + IV_SIZE + MAC_SIZE + encryptedPayload.Length];
+                Memory<byte> outputBufferMemory = outputBuffer;
+                _version1.CopyTo(outputBufferMemory);
+                aes.IV.CopyTo(outputBufferMemory.Slice(VERSION_SIZE));
+                mac.CopyTo(outputBufferMemory.Slice(VERSION_SIZE + IV_SIZE));
+                encryptedPayload.CopyTo(outputBufferMemory.Slice(VERSION_SIZE + IV_SIZE + MAC_SIZE));
                 return outputBuffer;
             }
         }
 
         public async Task<byte[]> UnprotectAsync(byte[] payload, CancellationToken cancellationToken)
         {
+            if (!payload.AsSpan().Slice(0, 1).SequenceEqual(_version1))
+            {
+                throw new InvalidOperationException("Unknown payload version.");
+            }
             var keys = await ExpandKeysAsync(cancellationToken);
-            var iv = new byte[128 / 8];
-            Buffer.BlockCopy(payload, 0, iv, 0, iv.Length);
-            var mac = new byte[32];
-            Buffer.BlockCopy(payload, iv.Length, mac, 0, 32);
+            var iv = new byte[IV_SIZE];
+            Buffer.BlockCopy(payload, VERSION_SIZE, iv, 0, iv.Length);
+            var mac = new byte[MAC_SIZE];
+            Buffer.BlockCopy(payload, VERSION_SIZE + IV_SIZE, mac, 0, mac.Length);
+            VerifyMac(payload, mac, keys.MacKey);
             byte[] plaintext;
             using (var aes = Aes.Create())
             using (var crypto = aes.CreateDecryptor(keys.CipherKey, iv))
             using (var stream = new MemoryStream())
             using (var cryptoStream = new CryptoStream(stream, crypto, CryptoStreamMode.Write))
             {
-                await cryptoStream.WriteAsync(payload, iv.Length + mac.Length, payload.Length - iv.Length - mac.Length, cancellationToken);
+                var payloadPosition = VERSION_SIZE + MAC_SIZE + IV_SIZE;
+                await cryptoStream.WriteAsync(payload, payloadPosition, payload.Length - payloadPosition, cancellationToken);
                 cryptoStream.FlushFinalBlock();
                 plaintext = stream.ToArray();
             }
 
-            VerifyMac(payload, mac, keys.MacKey);
-
             return plaintext;
         }
 
-        private byte[] ComputeMac(byte[] macKey, byte[] buffer, int offset, int count)
+        private byte[] ComputeMac(byte[] macKey, ArraySegment<byte> version, ArraySegment<byte> iv, ArraySegment<byte> ciphertext)
         {
-            using (var hmac = new HMACSHA256(macKey))
+            using (var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, macKey))
             {
-                return hmac.ComputeHash(buffer, offset, count);
+                hmac.AppendData(version.Array, version.Offset, version.Count);
+                hmac.AppendData(iv.Array, iv.Offset, iv.Count);
+                hmac.AppendData(ciphertext.Array, ciphertext.Offset, ciphertext.Count);
+                return hmac.GetHashAndReset();
             }
         }
 
         private void VerifyMac(byte[] payload, byte[] mac, byte[] macKey)
         {
-            var payloadMac = ComputeMac(macKey, payload, 16 + 32, payload.Length - (16 + 32));
+            if (payload.Length < VERSION_SIZE + IV_SIZE + MAC_SIZE)
+            {
+                throw new MacMismatchException("MAC mismatch");
+            }
+            var versionSegment = new ArraySegment<byte>(payload, 0, VERSION_SIZE);
+            var ivSegment = new ArraySegment<byte>(payload, VERSION_SIZE, IV_SIZE);
+            var macSegment = new ArraySegment<byte>(payload, VERSION_SIZE + IV_SIZE, MAC_SIZE);
+            var payloadSegment = new ArraySegment<byte>(
+                payload,
+                VERSION_SIZE + IV_SIZE + MAC_SIZE,
+                payload.Length - (VERSION_SIZE + IV_SIZE + MAC_SIZE));
+            var payloadMac = ComputeMac(macKey, versionSegment, ivSegment, payloadSegment);
 
             if (mac.Length != payloadMac.Length)
             {
                 throw new MacMismatchException("MAC mismatch");
             }
 
-            var mismatch = false;
+            var mismatch = 0;
             for (var i = 0; i < mac.Length; i++)
             {
-                if (mac[i] != payloadMac[i])
-                {
-                    mismatch = true;
-                }
+                mismatch |= mac[i] ^ payloadMac[i];
             }
 
-            if (mismatch)
+            if (mismatch != 0)
             {
                 throw new MacMismatchException("MAC mismatch");
             }


### PR DESCRIPTION
This PR is meant to address a few issues with how data was authenticated with an HMAC.

- The IV was not considered part of the HMAC. This meant the IV in the payload could be mutated without causing an MAC failure.
- This introduces a "version" prefix on the payload (in plain text) so that the unprotector can handle change to how the binary payload is formed. e.g. if you want to change the MAC size or something. This change is "breaking", that is previously protected data cannot be unprotected with these changes. I'm not sure how to address this since there was no version initially. There is at least going forward. The version is part of the MAC as well.
- The MAC was being validated after decryption. This greatly reduces the usefulness of the MAC since a padding error will be raised before the MAC check stops it.