### PR TITLE
Fixed issue that causes the Quidjibo to stop when it fails to retrieve work items.

### DIFF
--- a/src/Quidjibo/Servers/QuidjiboServer.cs
+++ b/src/Quidjibo/Servers/QuidjiboServer.cs
@@ -151,7 +151,7 @@ namespace Quidjibo.Servers
                     _throttle.Release();
                 }
 
-                if (items.Count <= 0)
+                if (items == null || items.Count <= 0)
                 {
                     await Task.Delay(pollingInterval, _cts.Token);
                 }


### PR DESCRIPTION
This can occur when items are retrieved using a web proxy and the Quidjibo host server
is available, but returns a bad response.