### PR TITLE
Allow publish with a specific expiration date

### DIFF
--- a/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
+++ b/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Quidjibo.Models;
+using Quidjibo.SqlServer.Extensions;
+using Quidjibo.SqlServer.Providers;
+using Quidjibo.SqlServer.Utils;
+
+namespace Quidjibo.SqlServer.Tests.Extensions
+{
+    [TestClass]
+    public class SqlCommandExtensionsTests
+    {
+        private Random _random = new Random();
+
+        [TestMethod]
+        public async Task PrepareForSendAsync_SetCommandParameters()
+        {
+            // Arrange
+            WorkItem item = GenFu.GenFu.New<WorkItem>();
+            item.ScheduleId = Guid.NewGuid();
+            item.Payload = new byte[128];
+            _random.NextBytes(item.Payload);
+            SqlCommand cmd = new SqlCommand();
+
+            // Act
+            await cmd.PrepareForSendAsync(item, 0, CancellationToken.None);
+
+            // Assert
+            cmd.CommandText.Should().Be(await SqlLoader.GetScript("Work.Send"));
+            cmd.Parameters.Count.Should().Be(12);
+            cmd.Parameters["@Id"].Value.Should().Be(item.Id);
+            cmd.Parameters["@ScheduleId"].Value.Should().Be(item.ScheduleId);
+            cmd.Parameters["@CorrelationId"].Value.Should().Be(item.CorrelationId);
+            cmd.Parameters["@Name"].Value.Should().Be(item.Name);
+            cmd.Parameters["@Worker"].Value.Should().Be(item.Worker);
+            cmd.Parameters["@Queue"].Value.Should().Be(item.Queue);
+            cmd.Parameters["@Attempts"].Value.Should().Be(item.Attempts);
+            cmd.Parameters["@CreatedOn"].Value.Should().Match<DateTime>(
+                x => x > DateTime.UtcNow.AddMinutes(-1) && x < DateTime.UtcNow.AddMinutes(1),
+                "because it should always be set to UtcNow");
+            cmd.Parameters["@ExpireOn"].Value.Should().Match<DateTime>(
+                x => x.Date == DateTime.UtcNow.AddDays(7).Date,
+                "because work expires after 7 days, by default");
+            cmd.Parameters["@VisibleOn"].Value.Should().Be(
+                cmd.Parameters["@CreatedOn"].Value,
+                "because there is no delay");
+            cmd.Parameters["@Status"].Value.Should().Be(SqlWorkProvider.StatusFlags.New);
+            cmd.Parameters["@Payload"].Value.Should().Be(item.Payload);
+        }
+
+        [DataTestMethod]
+        [DataRow(0)]
+        [DataRow(1)]
+        [DataRow(100)]
+        public async Task PrepareForSendAsync_AdjustVisibleOnAccordingToDelay(int delay)
+        {
+            // Arrange
+            WorkItem item = GenFu.GenFu.New<WorkItem>();
+            SqlCommand cmd = new SqlCommand();
+
+            // Act
+            await cmd.PrepareForSendAsync(item, delay, CancellationToken.None);
+
+            // Assert
+            DateTime createdOn = (DateTime)cmd.Parameters["@CreatedOn"].Value;
+            cmd.Parameters["@VisibleOn"].Value.Should().Be(createdOn.AddSeconds(delay));
+        }
+
+
+    }
+}

--- a/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
+++ b/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
@@ -44,9 +44,7 @@ namespace Quidjibo.SqlServer.Tests.Extensions
             cmd.Parameters["@CreatedOn"].Value.Should().Match<DateTime>(
                 x => x > DateTime.UtcNow.AddMinutes(-1) && x < DateTime.UtcNow.AddMinutes(1),
                 "because it should always be set to UtcNow");
-            cmd.Parameters["@ExpireOn"].Value.Should().Match<DateTime>(
-                x => x.Date == DateTime.UtcNow.AddDays(7).Date,
-                "because work expires after 7 days, by default");
+            cmd.Parameters["@ExpireOn"].Value.Should().Be(item.ExpireOn);
             cmd.Parameters["@VisibleOn"].Value.Should().Be(
                 cmd.Parameters["@CreatedOn"].Value,
                 "because there is no delay");
@@ -72,6 +70,19 @@ namespace Quidjibo.SqlServer.Tests.Extensions
             cmd.Parameters["@VisibleOn"].Value.Should().Be(createdOn.AddSeconds(delay));
         }
 
+        [TestMethod]
+        public async Task PrepareForSendAsync_ExpireOnIsNotSet_ShouldSetExpireOnToDefault()
+        {
+            // Arrange
+            WorkItem item = GenFu.GenFu.New<WorkItem>();
+            item.ExpireOn = default;
+            SqlCommand cmd = new SqlCommand();
 
+            // Act
+            await cmd.PrepareForSendAsync(item, 0, CancellationToken.None);
+
+            // Assert
+            cmd.Parameters["@ExpireOn"].Value.Should().Match<DateTime>(x => x.Date == DateTime.UtcNow.AddDays(SqlWorkProvider.DEFAULT_EXPIRE_DAYS).Date);
+        }
     }
 }

--- a/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
+++ b/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
@@ -125,6 +125,24 @@ namespace Quidjibo.SqlServer.Tests.Extensions
         }
                 
         [TestMethod]
+        public async Task PrepareForReneweAsync_SetCommandParameters()
+        {
+            // Arrange
+            WorkItem item = GenFu.GenFu.New<WorkItem>();
+            DateTime lockExpireOn = DateTime.UtcNow.AddSeconds(60);
+            SqlCommand cmd = new SqlCommand();
+
+            // Act
+            await cmd.PrepareForRenewAsync(item, lockExpireOn, CancellationToken.None);
+
+            // Assert
+            cmd.CommandText.Should().Be(await SqlLoader.GetScript("Work.Renew"));
+            cmd.Parameters.Count.Should().Be(2);
+            cmd.Parameters["@Id"].Value.Should().Be(item.Id);
+            cmd.Parameters["@VisibleOn"].Value.Should().Be(lockExpireOn);
+        }
+                
+        [TestMethod]
         public async Task PrepareForCompleteAsync_SetCommandParameters()
         {
             // Arrange

--- a/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
+++ b/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
@@ -123,6 +123,23 @@ namespace Quidjibo.SqlServer.Tests.Extensions
             cmd.Parameters["@VisibleOn"].Value.Should().Match<DateTime>(x => x < DateTime.UtcNow.AddSeconds(30));
             cmd.Parameters["@Faulted"].Value.Should().Be(SqlWorkProvider.StatusFlags.Faulted);
         }
+                
+        [TestMethod]
+        public async Task PrepareForCompleteAsync_SetCommandParameters()
+        {
+            // Arrange
+            WorkItem item = GenFu.GenFu.New<WorkItem>();
+            SqlCommand cmd = new SqlCommand();
+
+            // Act
+            await cmd.PrepareForCompleteAsync(item, CancellationToken.None);
+
+            // Assert
+            cmd.CommandText.Should().Be(await SqlLoader.GetScript("Work.Complete"));
+            cmd.Parameters.Count.Should().Be(2);
+            cmd.Parameters["@Id"].Value.Should().Be(item.Id);
+            cmd.Parameters["@Complete"].Value.Should().Be(SqlWorkProvider.StatusFlags.Complete);
+        }
 
     }
 }

--- a/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
+++ b/src/Quidjibo.SqlServer.Tests/Extensions/SqlCommandExtensionsTests.cs
@@ -75,7 +75,7 @@ namespace Quidjibo.SqlServer.Tests.Extensions
         {
             // Arrange
             WorkItem item = GenFu.GenFu.New<WorkItem>();
-            item.ExpireOn = default;
+            item.ExpireOn = default(DateTime);
             SqlCommand cmd = new SqlCommand();
 
             // Act

--- a/src/Quidjibo.SqlServer.Tests/Quidjibo.SqlServer.Tests.csproj
+++ b/src/Quidjibo.SqlServer.Tests/Quidjibo.SqlServer.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Quidjibo\Quidjibo.csproj" />
+    <ProjectReference Include="..\Quidjibo.SqlServer\Quidjibo.SqlServer.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
+++ b/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
@@ -17,7 +17,7 @@ namespace Quidjibo.SqlServer.Extensions
         {
             var createdOn = DateTime.UtcNow;
             var visibleOn = createdOn.AddSeconds(delay);
-            var expireOn = visibleOn.AddDays(7);
+            var expireOn = item.ExpireOn == default ? visibleOn.AddDays(SqlWorkProvider.DEFAULT_EXPIRE_DAYS) : item.ExpireOn;
 
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
             cmd.CommandText = await SqlLoader.GetScript("Work.Send");
@@ -35,6 +35,7 @@ namespace Quidjibo.SqlServer.Extensions
             cmd.AddParameter("@Status", SqlWorkProvider.StatusFlags.New);
             cmd.AddParameter("@Payload", item.Payload);
         }
+      
     }
 
 }

--- a/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
+++ b/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
@@ -17,7 +17,7 @@ namespace Quidjibo.SqlServer.Extensions
         {
             var createdOn = DateTime.UtcNow;
             var visibleOn = createdOn.AddSeconds(delay);
-            var expireOn = item.ExpireOn == default ? visibleOn.AddDays(SqlWorkProvider.DEFAULT_EXPIRE_DAYS) : item.ExpireOn;
+            var expireOn = item.ExpireOn == default(DateTime) ? visibleOn.AddDays(SqlWorkProvider.DEFAULT_EXPIRE_DAYS) : item.ExpireOn;
 
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
             cmd.CommandText = await SqlLoader.GetScript("Work.Send");

--- a/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
+++ b/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
@@ -36,6 +36,15 @@ namespace Quidjibo.SqlServer.Extensions
             cmd.AddParameter("@Payload", item.Payload);
         }
 
+        public static async Task PrepareForRenewAsync(this SqlCommand cmd, WorkItem item, DateTime lockExpireOn, CancellationToken cancellationToken)
+        {
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+                cmd.CommandText = await SqlLoader.GetScript("Work.Renew");
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+                cmd.AddParameter("@Id", item.Id);
+                cmd.AddParameter("@VisibleOn", lockExpireOn);
+        }
+
         public static async Task PrepareForCompleteAsync(this SqlCommand cmd, WorkItem item, CancellationToken cancellationToken)
         {
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities

--- a/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
+++ b/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
@@ -36,6 +36,15 @@ namespace Quidjibo.SqlServer.Extensions
             cmd.AddParameter("@Payload", item.Payload);
         }
 
+        public static async Task PrepareForCompleteAsync(this SqlCommand cmd, WorkItem item, CancellationToken cancellationToken)
+        {
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+            cmd.CommandText = await SqlLoader.GetScript("Work.Complete");
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+            cmd.AddParameter("@Id", item.Id);
+            cmd.AddParameter("@Complete", SqlWorkProvider.StatusFlags.Complete);
+        }
+
         public static async Task PrepareForFaultAsync(this SqlCommand cmd, WorkItem item, int visibilityTimeout, CancellationToken cancellationToken)
         {
             var faultedOn = DateTime.UtcNow;

--- a/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
+++ b/src/Quidjibo.SqlServer/Extensions/SqlCommandExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) smiggleworth. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Quidjibo.Models;
+using Quidjibo.SqlServer.Providers;
+using Quidjibo.SqlServer.Utils;
+
+namespace Quidjibo.SqlServer.Extensions
+{
+    public static class SqlCommandExtensions
+    {
+        public static async Task PrepareForSendAsync(this SqlCommand cmd, WorkItem item, int delay, CancellationToken cancellationToken)
+        {
+            var createdOn = DateTime.UtcNow;
+            var visibleOn = createdOn.AddSeconds(delay);
+            var expireOn = visibleOn.AddDays(7);
+
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+            cmd.CommandText = await SqlLoader.GetScript("Work.Send");
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+            cmd.AddParameter("@Id", item.Id);
+            cmd.AddParameter("@ScheduleId", item.ScheduleId);
+            cmd.AddParameter("@CorrelationId", item.CorrelationId);
+            cmd.AddParameter("@Name", item.Name);
+            cmd.AddParameter("@Worker", item.Worker);
+            cmd.AddParameter("@Queue", item.Queue);
+            cmd.AddParameter("@Attempts", item.Attempts);
+            cmd.AddParameter("@CreatedOn", createdOn);
+            cmd.AddParameter("@ExpireOn", expireOn);
+            cmd.AddParameter("@VisibleOn", visibleOn);
+            cmd.AddParameter("@Status", SqlWorkProvider.StatusFlags.New);
+            cmd.AddParameter("@Payload", item.Payload);
+        }
+    }
+
+}

--- a/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
+++ b/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
@@ -136,9 +136,7 @@ namespace Quidjibo.SqlServer.Providers
         {
             await ExecuteAsync(async cmd =>
             {
-                cmd.CommandText = await SqlLoader.GetScript("Work.Complete");
-                cmd.AddParameter("@Id", item.Id);
-                cmd.AddParameter("@Complete", StatusFlags.Complete);
+                await cmd.PrepareForCompleteAsync(item, cancellationToken);
                 await cmd.ExecuteNonQueryAsync(cancellationToken);
             }, cancellationToken);
         }

--- a/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
+++ b/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
@@ -54,26 +54,11 @@ namespace Quidjibo.SqlServer.Providers
 
         public async Task SendAsync(WorkItem item, int delay, CancellationToken cancellationToken)
         {
-            var createdOn = DateTime.UtcNow;
-            var visibleOn = createdOn.AddSeconds(delay);
-            var expireOn = visibleOn.AddDays(7);
             await ExecuteAsync(async cmd =>
             {
-                cmd.CommandText = await SqlLoader.GetScript("Work.Send");
-                cmd.AddParameter("@Id", item.Id);
-                cmd.AddParameter("@ScheduleId", item.ScheduleId);
-                cmd.AddParameter("@CorrelationId", item.CorrelationId);
-                cmd.AddParameter("@Name", item.Name);
-                cmd.AddParameter("@Worker", item.Worker);
-                cmd.AddParameter("@Queue", item.Queue);
-                cmd.AddParameter("@Attempts", item.Attempts);
-                cmd.AddParameter("@CreatedOn", createdOn);
-                cmd.AddParameter("@ExpireOn", expireOn);
-                cmd.AddParameter("@VisibleOn", visibleOn);
-                cmd.AddParameter("@Status", StatusFlags.New);
-                cmd.AddParameter("@Payload", item.Payload);
+                await cmd.PrepareForSendAsync(item, delay, cancellationToken);
                 await cmd.ExecuteNonQueryAsync(cancellationToken);
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<List<WorkItem>> ReceiveAsync(string worker, CancellationToken cancellationToken)

--- a/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
+++ b/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
@@ -124,9 +124,7 @@ namespace Quidjibo.SqlServer.Providers
             var lockExpireOn = (item.VisibleOn ?? DateTime.UtcNow).AddSeconds(Math.Max(_visibilityTimeout, 30));
             await ExecuteAsync(async cmd =>
             {
-                cmd.CommandText = await SqlLoader.GetScript("Work.Renew");
-                cmd.AddParameter("@Id", item.Id);
-                cmd.AddParameter("@VisibleOn", lockExpireOn);
+                await cmd.PrepareForRenewAsync(item, lockExpireOn, cancellationToken);
                 await cmd.ExecuteNonQueryAsync(cancellationToken);
             }, cancellationToken);
             return lockExpireOn;

--- a/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
+++ b/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
@@ -145,13 +145,9 @@ namespace Quidjibo.SqlServer.Providers
 
         public async Task FaultAsync(WorkItem item, CancellationToken cancellationToken)
         {
-            var faultedOn = DateTime.UtcNow;
             await ExecuteAsync(async cmd =>
             {
-                cmd.CommandText = await SqlLoader.GetScript("Work.Fault");
-                cmd.AddParameter("@Id", item.Id);
-                cmd.AddParameter("@VisibleOn", faultedOn.AddSeconds(Math.Max(_visibilityTimeout, 30)));
-                cmd.AddParameter("@Faulted", StatusFlags.Faulted);
+                await cmd.PrepareForFaultAsync(item, _visibilityTimeout, cancellationToken);
                 await cmd.ExecuteNonQueryAsync(cancellationToken);
             }, cancellationToken);
         }

--- a/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
+++ b/src/Quidjibo.SqlServer/Providers/SqlWorkProvider.cs
@@ -25,6 +25,8 @@ namespace Quidjibo.SqlServer.Providers
             Complete = 2
         }
 
+        public const int DEFAULT_EXPIRE_DAYS = 7;
+
         private readonly int _batchSize;
         private readonly string _connectionString;
         private readonly int _daysToKeep;

--- a/src/Quidjibo.Tests/Clients/QuidjiboClientTests.cs
+++ b/src/Quidjibo.Tests/Clients/QuidjiboClientTests.cs
@@ -147,21 +147,25 @@ namespace Quidjibo.Tests.Clients
             await _workProvider.Received(1).SendAsync(Arg.Is<WorkItem>(x => x.Queue == queueName), delay, cancellationToken);
         }
 
-
         [TestMethod]
-        public async Task PublishAsync_WithDelayAndExpireOnAndQueueName()
+        public async Task PublishAsync_WithPublishOptionsAndQueueName()
         {
             // Arrange
             var queueName = BaseValueGenerator.Word();
             var command = new BasicCommand();
             var delay = GenFu.GenFu.Random.Next();
             var expireOn = new DateTime(2032, 2, 27);
+            var publishOptions = new PublishOptions
+            {
+                Delay = delay,
+                ExpireOn = expireOn
+            };
             var cancellationToken = CancellationToken.None;
             _payloadSerializer.SerializeAsync(command, cancellationToken).Returns(Task.FromResult<byte[]>(null));
             _workProviderFactory.CreateAsync(queueName, cancellationToken).Returns(Task.FromResult(_workProvider));
 
             // Act 
-            await _sut.PublishAsync(command, queueName, delay, expireOn, cancellationToken);
+            await _sut.PublishAsync(command, queueName, publishOptions, cancellationToken);
 
             // Assert
             await _workProvider.Received(1).SendAsync(Arg.Is<WorkItem>(x => x.Queue == queueName && x.ExpireOn == expireOn), delay, cancellationToken);

--- a/src/Quidjibo.Tests/Clients/QuidjiboClientTests.cs
+++ b/src/Quidjibo.Tests/Clients/QuidjiboClientTests.cs
@@ -147,6 +147,26 @@ namespace Quidjibo.Tests.Clients
             await _workProvider.Received(1).SendAsync(Arg.Is<WorkItem>(x => x.Queue == queueName), delay, cancellationToken);
         }
 
+
+        [TestMethod]
+        public async Task PublishAsync_WithDelayAndExpireOnAndQueueName()
+        {
+            // Arrange
+            var queueName = BaseValueGenerator.Word();
+            var command = new BasicCommand();
+            var delay = GenFu.GenFu.Random.Next();
+            var expireOn = new DateTime(2032, 2, 27);
+            var cancellationToken = CancellationToken.None;
+            _payloadSerializer.SerializeAsync(command, cancellationToken).Returns(Task.FromResult<byte[]>(null));
+            _workProviderFactory.CreateAsync(queueName, cancellationToken).Returns(Task.FromResult(_workProvider));
+
+            // Act 
+            await _sut.PublishAsync(command, queueName, delay, expireOn, cancellationToken);
+
+            // Assert
+            await _workProvider.Received(1).SendAsync(Arg.Is<WorkItem>(x => x.Queue == queueName && x.ExpireOn == expireOn), delay, cancellationToken);
+        }
+
         [TestMethod]
         public async Task ScheduleAsync()
         {

--- a/src/Quidjibo.Tests/Clients/QuidjiboClientTests.cs
+++ b/src/Quidjibo.Tests/Clients/QuidjiboClientTests.cs
@@ -289,7 +289,7 @@ namespace Quidjibo.Tests.Clients
         }
 
         [TestMethod]
-        public async Task ScheudleAsync_ShouldHandleNoAssemblies()
+        public async Task ScheduleAsync_ShouldHandleNoAssemblies()
         {
             // Arrange 
             var cancellationToken = CancellationToken.None;
@@ -303,7 +303,7 @@ namespace Quidjibo.Tests.Clients
         }
 
         [TestMethod]
-        public async Task ScheudleAsync_ShouldHandleNullAssemblies()
+        public async Task ScheduleAsync_ShouldHandleNullAssemblies()
         {
             // Arrange 
             var cancellationToken = CancellationToken.None;

--- a/src/Quidjibo.sln.DotSettings
+++ b/src/Quidjibo.sln.DotSettings
@@ -221,6 +221,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Quidjibo/Clients/IQuidjiboClient.cs
+++ b/src/Quidjibo/Clients/IQuidjiboClient.cs
@@ -45,15 +45,14 @@ namespace Quidjibo.Clients
         Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, int delay, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        ///     Publish a fire-and-forget with a delay to a specific queue
+        ///     Publish a fire-and-forget with options to a specific queue
         /// </summary>
         /// <param name="command"></param>
         /// <param name="queueName">The name of the queue</param>
-        /// <param name="delay">Delay in seconds</param>
-        /// <param name="expireOn">Expires on date</param>
+        /// <param name="options">Publish options</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, int delay, DateTime expireOn, CancellationToken cancellationToken = default(CancellationToken));
+        Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, PublishOptions options, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         ///     Schedule a recurring job with a specified schedule

--- a/src/Quidjibo/Clients/IQuidjiboClient.cs
+++ b/src/Quidjibo/Clients/IQuidjiboClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Quidjibo.Commands;
 using Quidjibo.Models;
@@ -42,6 +43,17 @@ namespace Quidjibo.Clients
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, int delay, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        ///     Publish a fire-and-forget with a delay to a specific queue
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="delay">Delay in seconds</param>
+        /// <param name="expireOn">Expires on date</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, int delay, DateTime expireOn, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         ///     Schedule a recurring job with a specified schedule

--- a/src/Quidjibo/Clients/PublishOptions.cs
+++ b/src/Quidjibo/Clients/PublishOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Quidjibo.Clients
+{
+    public class PublishOptions
+    {
+        public int Delay { get; set; }
+        public DateTime ExpireOn { get; set; }
+    }
+}

--- a/src/Quidjibo/Clients/QuidjiboClient.cs
+++ b/src/Quidjibo/Clients/QuidjiboClient.cs
@@ -62,6 +62,11 @@ namespace Quidjibo.Clients
 
         public async Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, int delay, CancellationToken cancellationToken = default(CancellationToken))
         {
+            return await PublishAsync(command, queueName, delay, default, cancellationToken);
+        }
+
+        public async Task<PublishInfo> PublishAsync(IQuidjiboCommand command, string queueName, int delay, DateTime expireOn, CancellationToken cancellationToken = default(CancellationToken))
+        {
             var payload = await _payloadSerializer.SerializeAsync(command, cancellationToken);
             var protectedPayload = await _payloadProtector.ProtectAsync(payload, cancellationToken);
             var item = new WorkItem
@@ -71,7 +76,8 @@ namespace Quidjibo.Clients
                 Name = command.GetName(),
                 Attempts = 0,
                 Payload = protectedPayload,
-                Queue = queueName
+                Queue = queueName,
+                ExpireOn = expireOn
             };
             var provider = await GetOrCreateWorkProvider(queueName, cancellationToken);
             await provider.SendAsync(item, delay, cancellationToken);

--- a/src/Quidjibo/Clients/QuidjiboClient.cs
+++ b/src/Quidjibo/Clients/QuidjiboClient.cs
@@ -66,7 +66,7 @@ namespace Quidjibo.Clients
             var options = new PublishOptions
             {
                 Delay = delay,
-                ExpireOn = default
+                ExpireOn = default(DateTime)
             };
             return await PublishAsync(command, queueName, options, cancellationToken);
         }


### PR DESCRIPTION
Currently, when a command is published, it is added to the queue with a default expiration of 7 days by default and there is no way to adjust this. In some cases, we may need to override the default expiration (i.e. 20 minutes for a time sensitive operation). These changes allow a specific expiration date to be passed.